### PR TITLE
Do not use root user inside container

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -8,11 +8,22 @@ RUN apt-get update && apt-get install -y \
   vim \
   jq
 
+# grab gosu for easy step-down from root
+RUN gpg --keyserver ha.pool.sks-keyservers.net --recv-keys B42F6819007F00F88E364FD4036A9C25BF357DD4 \
+    && curl -o /usr/local/bin/gosu -SL "https://github.com/tianon/gosu/releases/download/1.4/gosu-$(dpkg --print-architecture)" \
+    && curl -o /usr/local/bin/gosu.asc -SL "https://github.com/tianon/gosu/releases/download/1.4/gosu-$(dpkg --print-architecture).asc" \
+    && gpg --verify /usr/local/bin/gosu.asc \
+    && rm /usr/local/bin/gosu.asc \
+    && chmod +x /usr/local/bin/gosu
+
 RUN ln -s /usr/bin/nodejs /usr/bin/node
 
 # Install firefox 31
 RUN (curl -SL http://ftp.mozilla.org/pub/mozilla.org/firefox/releases/31.0/linux-x86_64/en-US/firefox-31.0.tar.bz2 | tar xj -C /opt) \
 	&& ln -sf /opt/firefox/firefox /usr/bin/firefox
+
+ENV DEV_UID=1000 \
+    DEV_GID=1000
 
 ENV CI true
 ENV TRAVIS true
@@ -21,4 +32,9 @@ ENV PATH ~/.local/bin:$PATH
 ENV TRAVIS_COMMIT master
 
 WORKDIR /home/travis
+
+COPY docker-entrypoint.sh /
+RUN chmod +x /docker-entrypoint.sh
+ENTRYPOINT ["/docker-entrypoint.sh"]
+
 CMD ["/bin/bash"]

--- a/README.md
+++ b/README.md
@@ -151,7 +151,7 @@ all the maven dependencies (You know that "Maven downloads the Internet" thing).
 One way of fixing that is to share your own `.m2` repository with the container:
 
 ```bash
-docker run -ti -v $HOME/.m2/:/root/.m2/ -e JOB=CI ci ./travis.sh
+docker run -ti -e DEV_UID=$(id -u) -e DEV_GID=$(id -g) -v $HOME/.m2/:/root/.m2/ -e JOB=CI ci ./travis.sh
 ```
 
 This is **good** because the build will be faster and use less bandwidth.

--- a/docker-entrypoint.sh
+++ b/docker-entrypoint.sh
@@ -1,0 +1,9 @@
+#!/bin/bash
+
+set -e
+
+groupadd --gid $DEV_GID travis
+useradd --uid $DEV_UID --gid $DEV_GID --home-dir /home/travis travis
+chown travis:travis /home/travis
+
+exec gosu travis "$@"


### PR DESCRIPTION
On start of container create dedicated "travis" user with UID and GID
specified by environment variables DEV_UID and DEV_GID respectively,
and step-down from root user before execution of command provided by
user.

Demo:

```
$ ls -lA test
ls: cannot access test: No such file or directory

$ docker run -it -e DEV_UID=$UID -e DEV_GID=$GID -v $PWD:/home/travis --rm local-travis \
id && touch test
uid=1000(travis) gid=1000(travis) groups=1000(travis)

$ ls -lA test 
-rw-r--r-- 1 godin godin 0 Sep 13 22:08 test
```

Note that in case if user UID conflicts with UID already existing in container, message will look like:

```
$ docker run -it -e DEV_UID=0 -e DEV_GID=0 -v $PWD:/home/travis --rm local-travis bash
groupadd: GID '0' already exists
```

The Linux Standard Base Core Specification specifies that range of UIDs from 0 to 500 is reserved. Leopard Security Config p.60 specifies that "new users created using the Accounts pane of System Preferences are assigned user IDs starting at 501". Thus IMO appearance of conflict is unlikely:

```
$ docker run -it -e DEV_UID=$UID -e DEV_GID=$GID -v $PWD:/home/travis --rm local-travis \
awk -F: '{if ($3 >= 500) { print $1 ":" $3 } }' /etc/passwd
nobody:65534
travis:1000
```

However, if this ever happens, then we can add "--non-unique" option for "useradd" and "groupadd".
